### PR TITLE
Use `MEMORY_WORKING_SET_EX_INFORMATION.SharedOriginal` to detect CoW regions on 1709+

### DIFF
--- a/Headers/Typedefs.h
+++ b/Headers/Typedefs.h
@@ -29,6 +29,59 @@ typedef struct _MEMORY_IMAGE_INFORMATION {
 	};
 } MEMORY_IMAGE_INFORMATION, * PMEMORY_IMAGE_INFORMATION;
 
+// c/o SystemInformer: https://github.com/winsiderss/systeminformer/blob/e01be6536a74464446687e75b0e34c3988d875d8/phnt/include/ntmmapi.h#L168C1-L229C74
+typedef struct _MEMORY_WORKING_SET_EX_BLOCK
+{
+    union
+    {
+        struct
+        {
+            ULONG_PTR Valid : 1;
+            ULONG_PTR ShareCount : 3;
+            ULONG_PTR Win32Protection : 11;
+            ULONG_PTR Shared : 1;
+            ULONG_PTR Node : 6;
+            ULONG_PTR Locked : 1;
+            ULONG_PTR LargePage : 1;
+            ULONG_PTR Priority : 3;
+            ULONG_PTR Reserved : 3;
+            ULONG_PTR SharedOriginal : 1;
+            ULONG_PTR Bad : 1;
+            ULONG_PTR Win32GraphicsProtection : 4; // 19H1
+#ifdef _WIN64
+            ULONG_PTR ReservedUlong : 28;
+#endif
+        };
+        struct
+        {
+            ULONG_PTR Valid : 1;
+            ULONG_PTR Reserved0 : 14;
+            ULONG_PTR Shared : 1;
+            ULONG_PTR Reserved1 : 5;
+            ULONG_PTR PageTable : 1;
+            ULONG_PTR Location : 2;
+            ULONG_PTR Priority : 3;
+            ULONG_PTR ModifiedList : 1;
+            ULONG_PTR Reserved2 : 2;
+            ULONG_PTR SharedOriginal : 1;
+            ULONG_PTR Bad : 1;
+#ifdef _WIN64
+            ULONG_PTR ReservedUlong : 32;
+#endif
+        } Invalid;
+    };
+} MEMORY_WORKING_SET_EX_BLOCK, * PMEMORY_WORKING_SET_EX_BLOCK;
+
+typedef struct _MEMORY_WORKING_SET_EX_INFORMATION
+{
+    PVOID VirtualAddress;
+    union
+    {
+        MEMORY_WORKING_SET_EX_BLOCK VirtualAttributes;
+        ULONG_PTR Long;
+    };
+} MEMORY_WORKING_SET_EX_INFORMATION, * PMEMORY_WORKING_SET_EX_INFORMATION;
+
 typedef struct _THREAD_BASIC_INFORMATION {
 	NTSTATUS                ExitStatus;
 	PVOID                   TebBaseAddress;
@@ -44,3 +97,4 @@ typedef BOOL(WINAPI* IsWow64Process_t) (HANDLE, PBOOL);
 typedef NTSTATUS(NTAPI *NtQueryInformationProcess_t)(HANDLE ProcessHandle, PROCESSINFOCLASS ProcessInformationClass, PVOID ProcessInformation, ULONG ProcessInformationLength, PULONG ReturnLength);
 typedef NTSTATUS(NTAPI* NtOpenSection_t)(HANDLE*, ACCESS_MASK, POBJECT_ATTRIBUTES);
 typedef void (NTAPI* RtlInitUnicodeString_t)(UNICODE_STRING*, const wchar_t*);
+typedef NTSTATUS (NTAPI * RtlGetVersion_t)(PRTL_OSVERSIONINFOW lpVersionInformation);

--- a/Source/Console.cpp
+++ b/Source/Console.cpp
@@ -151,7 +151,7 @@ int32_t wmain(int32_t nArgc, const wchar_t* pArgv[]) {
 			"\\____|__  /\\____/|___|  /\\___  >__| (____  /\r\n"
 			"        \\/            \\/     \\/          \\/ \r\n"
 			"\r\n"
-			"Moneta v1.0 | Forrest Orr | 2020\r\n\r\n"
+			"Moneta v1.0.1 | Forrest Orr | 2024\r\n\r\n"
 		);
 	}
 


### PR DESCRIPTION
It's possible to reset the `MEMORY_WORKING_SET_EX_INFORMATION.Shared` bit, hiding the fact that a memory region is CoW.  Microsoft accounted for this when implementing [module tampering protection](https://windows-internals.com/understanding-a-new-mitigation-module-tampering-protection/).  Moneta can easily do the same.

Example bypass: https://x.com/KlezVirus/status/1758428205285785698?s=20
That bypass doesn't defeat `SharedOriginal`: https://x.com/ilove2pwn_/status/1724176577506722150?s=20

Here is this branch (left) detecting a bypass that `v1.0` (right) doesn't: 
![image](https://github.com/forrest-orr/moneta/assets/42078554/8928299c-d0ec-468d-8c88-6b8bae952cb5)
